### PR TITLE
1.6.0 - Burst improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ A Home Assistant custom integration for indexing and querying media files with E
 
 ## Project Overview
 
-**Current Version**: v1.5.10
+**Current Version**: v1.6.0
 **Status**: Production ready
 **Type**: Home Assistant Custom Integration (Python)
 
@@ -319,7 +319,7 @@ Located in `scripts/`:
 ### When Making Changes
 
 1. Make code changes
-2. Update CHANGELOG.md under **current version** (e.g., v1.5.10)
+2. Update CHANGELOG.md under **current version** (e.g., v1.6.0)
 3. Add to appropriate section (Added/Changed/Fixed)
 4. **DO NOT** update version in manifest.json
 5. Commit with descriptive message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.10] - 2026-01-12
+## [1.6.0] 2026-04-12
 
 ### Added
 
-- **`index_burst_groups` Service**: One-shot service that scans the entire library (O(n log n)) and writes `burst_group_id` and `burst_count` to every file in each burst group
-  - Groups photos by time proximity (15s window) and optional GPS sub-clustering (20m tolerance)
+- **`index_burst_groups` Service**: One-shot service that scans the entire library (O(n log n)) and writes `burst_favorites` and `burst_count` to every file in every burst group
+  - Groups photos by time proximity (10s window, configurable) and optional GPS sub-clustering (50m tolerance, configurable)
   - Writes results in 500-row commit batches to stay memory-efficient on large libraries
   - Returns `{groups_found, files_updated, files_skipped, errors}` for progress feedback
   - Run this once (or after bulk imports) to enable backend-level burst filtering in `get_random_items`
@@ -18,8 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`auto_select_burst_favorite` Parameter for `get_random_items`**: When `true`, the SQL query excludes non-favorite burst members whose group has at least one indexed favorite
   - Filtering is done in the database before results are sent to the card — no client-side splicing or timers
-  - Only applies to files where `burst_group_id` is set (i.e., `index_burst_groups` has run); non-indexed files are returned normally
-  - Used automatically by Media Card v5.9.1+ when `auto_select_burst_favorite: true` is configured
+  - Only applies to files where `burst_count` is set (i.e., `index_burst_groups` has run); non-indexed files are returned normally
+  - Used automatically by Media Card v5.9.0+ when `auto_select_burst_favorite: true` is configured
+
+
+### Fixed
+
+- **`get_burst_photos` Iterative Flood-Fill**: Replaced naive single-pass grouping with an iterative convergence algorithm so all members of a burst group get the same result regardless of which photo is used as the reference
+  - Previously, a 3-photo burst could return 2 members when queried from photo A and 3 members when queried from photo B (depending on which pair was within the time window of the reference)
+  - Now iterates until the full connected set stabilises (typically 1–2 passes on real bursts)
+
+
+## [1.5.10] - 2026-01-12
+
+## Added
 
 - **Compound Cursor Pagination for `get_ordered_files`**: Fixes duplicate results when files share the same date_taken
   - Added `after_id` parameter (secondary cursor) for tie-breaking when sort values are equal
@@ -28,10 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Backward compatible: `after_value` still works alone, `after_id` is optional
 
 ### Fixed
-
-- **`get_burst_photos` Iterative Flood-Fill**: Replaced naive single-pass grouping with an iterative convergence algorithm so all members of a burst group get the same result regardless of which photo is used as the reference
-  - Previously, a 3-photo burst could return 2 members when queried from photo A and 3 members when queried from photo B (depending on which pair was within the time window of the reference)
-  - Now iterates until the full connected set stabilises (typically 1–2 passes on real bursts)
 
 - **File Watcher Log Spam**: Reduced per-file logging to DEBUG level to prevent "logging too frequently" warnings
   - Changed individual file add/update/remove logs from INFO to DEBUG level
@@ -42,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Root cause: Simple cursor `after_value` couldn't distinguish between files with same date
   - Fix: Added `m.id` to ORDER BY clause for deterministic ordering: `ORDER BY sort_field DESC, m.id DESC`
   - Compound cursor allows advancing past all items with same date value
+
 
 ## [1.5.9] - 2026-01-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously, files previously in a group (e.g. with a 15s window) kept their old `burst_count` when re-indexed with a narrower window (e.g. 3s) — causing the metadata header to show the old count while the live burst panel query found fewer photos
   - Fix: all in-scope `burst_count` and `burst_favorites` values are reset before new groups are written (only when `overwrite_existing=True`)
 
+- **`index_burst_groups` Write Loop Now Uses `executemany` + Direct `file_id`**: Eliminated N subqueries per write batch
+  - Previously each write did `WHERE file_id = (SELECT id FROM media_files WHERE path = ?)` — one extra SELECT per file
+  - Fix: `file_id` (already fetched by the initial query) is stored in the pending-writes list; writes use `executemany` for a single batch statement per 500-row chunk
+  - `files_skipped` in the return value now reflects files not placed in any qualifying group (rather than rows with zero rowcount)
+
 - **Date Filtering Now Works for Files Without EXIF (`get_random_items`, `get_ordered_files`)**: Fixed silent type mismatch that caused date filters to be ignored when `date_taken` is NULL
   - Root cause (PR #25 by kamiyo): `m.created_time` and `m.modified_time` are stored as ISO strings, but `e.date_taken` is a Unix integer. When `e.date_taken` is NULL, `COALESCE` fell back to the ISO string which SQLite silently coerced to 0 — so comparisons against Unix timestamps always failed
   - Fix: wrap fallback columns with `unixepoch()` to convert ISO strings to integers before comparison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`index_burst_groups` Service**: One-shot service that scans the entire library (O(n log n)) and writes `burst_group_id` and `burst_count` to every file in each burst group
+  - Groups photos by time proximity (15s window) and optional GPS sub-clustering (20m tolerance)
+  - Writes results in 500-row commit batches to stay memory-efficient on large libraries
+  - Returns `{groups_found, files_updated, files_skipped, errors}` for progress feedback
+  - Run this once (or after bulk imports) to enable backend-level burst filtering in `get_random_items`
+  - See `media_index.index_burst_groups` in the services documentation
+
+- **`auto_select_burst_favorite` Parameter for `get_random_items`**: When `true`, the SQL query excludes non-favorite burst members whose group has at least one indexed favorite
+  - Filtering is done in the database before results are sent to the card — no client-side splicing or timers
+  - Only applies to files where `burst_group_id` is set (i.e., `index_burst_groups` has run); non-indexed files are returned normally
+  - Used automatically by Media Card v5.9.1+ when `auto_select_burst_favorite: true` is configured
+
 - **Compound Cursor Pagination for `get_ordered_files`**: Fixes duplicate results when files share the same date_taken
   - Added `after_id` parameter (secondary cursor) for tie-breaking when sort values are equal
   - Uses `(after_value, after_id)` compound ordering: `(sort_field < value) OR (sort_field = value AND id < after_id)`
@@ -16,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Backward compatible: `after_value` still works alone, `after_id` is optional
 
 ### Fixed
+
+- **`get_burst_photos` Iterative Flood-Fill**: Replaced naive single-pass grouping with an iterative convergence algorithm so all members of a burst group get the same result regardless of which photo is used as the reference
+  - Previously, a 3-photo burst could return 2 members when queried from photo A and 3 members when queried from photo B (depending on which pair was within the time window of the reference)
+  - Now iterates until the full connected set stabilises (typically 1–2 passes on real bursts)
 
 - **File Watcher Log Spam**: Reduced per-file logging to DEBUG level to prevent "logging too frequently" warnings
   - Changed individual file add/update/remove logs from INFO to DEBUG level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Previously, a 3-photo burst could return 2 members when queried from photo A and 3 members when queried from photo B (depending on which pair was within the time window of the reference)
   - Now iterates until the full connected set stabilises (typically 1–2 passes on real bursts)
 
+- **`modified_time` Sort Order Now Numeric in `get_ordered_files`**: `order_by: modified_time` now maps to `unixepoch(m.modified_time)` instead of raw `m.modified_time`
+  - `m.modified_time` is stored as an ISO 8601 string; sorting it lexicographically can produce incorrect order compared to the numeric `date_taken` fallback introduced in v1.6.0
+  - Fix: wrapping with `unixepoch()` ensures consistent numeric comparison for all sort fields
+
+- **`auto_select_burst_favorite` Added to `services.yaml`**: The parameter was functional but missing from the service definition, so it did not appear in the Home Assistant service UI
+  - Added boolean field to `get_random_items` service definition with description and default value
+
 
 ## [1.5.10] - 2026-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`index_burst_groups` Now Clears Stale Burst Data Before Re-indexing**: Re-running with a narrower time window now correctly removes burst groups from files that no longer qualify
+  - Previously, files previously in a group (e.g. with a 15s window) kept their old `burst_count` when re-indexed with a narrower window (e.g. 3s) — causing the metadata header to show the old count while the live burst panel query found fewer photos
+  - Fix: all in-scope `burst_count` and `burst_favorites` values are reset before new groups are written (only when `overwrite_existing=True`)
+
 - **Date Filtering Now Works for Files Without EXIF (`get_random_items`, `get_ordered_files`)**: Fixed silent type mismatch that caused date filters to be ignored when `date_taken` is NULL
   - Root cause (PR #25 by kamiyo): `m.created_time` and `m.modified_time` are stored as ISO strings, but `e.date_taken` is a Unix integer. When `e.date_taken` is NULL, `COALESCE` fell back to the ISO string which SQLite silently coerced to 0 — so comparisons against Unix timestamps always failed
   - Fix: wrap fallback columns with `unixepoch()` to convert ISO strings to integers before comparison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.0] 2026-04-12
+## [1.6.0] - 2026-04-12
 
 ### Added
 
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Date Filtering Now Works for Files Without EXIF (`get_random_items`, `get_ordered_files`)**: Fixed silent type mismatch that caused date filters to be ignored when `date_taken` is NULL
+  - Root cause (PR #25 by kamiyo): `m.created_time` and `m.modified_time` are stored as ISO strings, but `e.date_taken` is a Unix integer. When `e.date_taken` is NULL, `COALESCE` fell back to the ISO string which SQLite silently coerced to 0 — so comparisons against Unix timestamps always failed
+  - Fix: wrap fallback columns with `unixepoch()` to convert ISO strings to integers before comparison
+  - Also fixes `strftime()` anniversary filters for the same reason (month/day matching was broken for files without EXIF)
+
+- **Date Fallback Now Uses Earliest of Created/Modified Time**: When `date_taken` EXIF is absent, filtering and sorting now use `MIN(unixepoch(m.created_time), unixepoch(m.modified_time))` instead of only `m.created_time`
+  - Fixes issue #24 (reported by kamiyo): copying files resets `created_time` to "now" on most OS/filesystems, causing old photos to appear as new — `modified_time` typically survives file copies and better reflects the original capture date
+  - Using the earlier of the two timestamps is the most conservative heuristic: whichever one was not reset by the copy is more likely the original date
+  - Applies to all date range filters, anniversary filters, and `date_taken` sort order in `get_ordered_files`
+
 - **`get_burst_photos` Iterative Flood-Fill**: Replaced naive single-pass grouping with an iterative convergence algorithm so all members of a burst group get the same result regardless of which photo is used as the reference
   - Previously, a 3-photo burst could return 2 members when queried from photo A and 3 members when queried from photo B (depending on which pair was within the time window of the reference)
   - Now iterates until the full connected set stabilises (typically 1–2 passes on real bursts)
@@ -31,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.10] - 2026-01-12
 
-## Added
+### Added
 
 - **Compound Cursor Pagination for `get_ordered_files`**: Fixes duplicate results when files share the same date_taken
   - Added `after_id` parameter (secondary cursor) for tie-breaking when sort values are equal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`index_burst_groups` Service**: One-shot service that scans the entire library (O(n log n)) and writes `burst_favorites` and `burst_count` to every file in every burst group
   - Groups photos by time proximity (10s window, configurable) and optional GPS sub-clustering (50m tolerance, configurable)
-  - Writes results in 500-row commit batches to stay memory-efficient on large libraries
+  - Streams rows from the database in 1000-row batches — memory footprint is O(burst_size), not O(library_size); safe for 200K+ libraries
+  - Writes results in 500-row commit batches
   - Returns `{groups_found, files_updated, files_skipped, errors}` for progress feedback
   - Run this once (or after bulk imports) to enable backend-level burst filtering in `get_random_items`
   - See `media_index.index_burst_groups` in the services documentation

--- a/custom_components/media_index/__init__.py
+++ b/custom_components/media_index/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     SERVICE_RESTORE_EDITED_FILES,
     SERVICE_CLEANUP_DATABASE,
     SERVICE_UPDATE_BURST_METADATA,
+    SERVICE_INDEX_BURST_GROUPS,
     SERVICE_INSTALL_LIBMEDIAINFO,
     SERVICE_CHECK_FILE_EXISTS,
 )
@@ -1557,7 +1558,48 @@ def _register_services(hass: HomeAssistant):
                 "status": "error",
                 "error": str(e)
             }
-    
+
+    async def handle_index_burst_groups(call):
+        """Handle index_burst_groups service call.
+
+        Scans the entire indexed library (or a sub-folder) and writes burst_count /
+        burst_favorites to every file that belongs to a detected burst group.  Designed
+        for large collections (200 K+ items) — uses a single sorted query then an
+        in-process walk rather than per-file DB round-trips.
+        """
+        entry_id = _get_entry_id_from_call(hass, call)
+        cache_manager = hass.data[DOMAIN][entry_id]["cache_manager"]
+
+        folder              = call.data.get("folder", None)
+        time_window         = call.data.get("time_window_seconds", 10)
+        location_tolerance  = call.data.get("location_tolerance_meters", 50)
+        min_group_size      = call.data.get("min_group_size", 2)
+        overwrite_existing  = call.data.get("overwrite_existing", True)
+
+        _LOGGER.info(
+            "index_burst_groups service called: folder=%s, window=%ds, min_size=%d, overwrite=%s",
+            folder or "all", time_window, min_group_size, overwrite_existing,
+        )
+
+        try:
+            result = await cache_manager.index_burst_groups(
+                folder=folder,
+                time_window_seconds=time_window,
+                location_tolerance_meters=location_tolerance,
+                min_group_size=min_group_size,
+                overwrite_existing=overwrite_existing,
+            )
+            return {
+                "status": "success",
+                **result,
+            }
+        except Exception as e:
+            _LOGGER.error("Error in index_burst_groups service: %s", e)
+            return {
+                "status": "error",
+                "error": str(e),
+            }
+
     async def handle_scan_folder(call):
         """Handle scan_folder service call."""
         entry_id = _get_entry_id_from_call(hass, call)
@@ -1755,7 +1797,21 @@ def _register_services(hass: HomeAssistant):
         }, extra=vol.ALLOW_EXTRA),
         supports_response=SupportsResponse.ONLY,
     )
-    
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_INDEX_BURST_GROUPS,
+        handle_index_burst_groups,
+        schema=vol.Schema({
+            vol.Optional("folder"): cv.string,
+            vol.Optional("time_window_seconds", default=10): cv.positive_int,
+            vol.Optional("location_tolerance_meters", default=50): cv.positive_int,
+            vol.Optional("min_group_size", default=2): cv.positive_int,
+            vol.Optional("overwrite_existing", default=True): cv.boolean,
+        }, extra=vol.ALLOW_EXTRA),
+        supports_response=SupportsResponse.ONLY,
+    )
+
     _LOGGER.info("Media Index services registered")
 
 

--- a/custom_components/media_index/__init__.py
+++ b/custom_components/media_index/__init__.py
@@ -1807,7 +1807,7 @@ def _register_services(hass: HomeAssistant):
         schema=vol.Schema({
             vol.Optional("folder"): cv.string,
             vol.Optional("time_window_seconds", default=10): cv.positive_int,
-            vol.Optional("location_tolerance_meters", default=50): cv.non_negative_int,
+            vol.Optional("location_tolerance_meters", default=50): vol.All(vol.Coerce(int), vol.Range(min=0)),
             vol.Optional("min_group_size", default=2): vol.All(cv.positive_int, vol.Range(min=2)),
             vol.Optional("overwrite_existing", default=True): cv.boolean,
         }, extra=vol.ALLOW_EXTRA),

--- a/custom_components/media_index/__init__.py
+++ b/custom_components/media_index/__init__.py
@@ -79,6 +79,7 @@ SERVICE_GET_RANDOM_ITEMS_SCHEMA = vol.Schema({
     vol.Optional("anniversary_window_days", default=0): cv.positive_int,
     vol.Optional("priority_new_files", default=False): cv.boolean,
     vol.Optional("new_files_threshold_seconds", default=3600): cv.positive_int,
+    vol.Optional("auto_select_burst_favorite", default=False): cv.boolean,
 }, extra=vol.ALLOW_EXTRA)
 
 SERVICE_GET_ORDERED_FILES_SCHEMA = vol.Schema({
@@ -810,6 +811,7 @@ def _register_services(hass: HomeAssistant):
             favorites_only=call.data.get("favorites_only", False),
             priority_new_files=call.data.get("priority_new_files", False),
             new_files_threshold_seconds=call.data.get("new_files_threshold_seconds", 3600),
+            auto_select_burst_favorite=call.data.get("auto_select_burst_favorite", False),
         )
         
         # Add media_source_uri to each item if configured

--- a/custom_components/media_index/__init__.py
+++ b/custom_components/media_index/__init__.py
@@ -1807,8 +1807,8 @@ def _register_services(hass: HomeAssistant):
         schema=vol.Schema({
             vol.Optional("folder"): cv.string,
             vol.Optional("time_window_seconds", default=10): cv.positive_int,
-            vol.Optional("location_tolerance_meters", default=50): cv.positive_int,
-            vol.Optional("min_group_size", default=2): cv.positive_int,
+            vol.Optional("location_tolerance_meters", default=50): cv.non_negative_int,
+            vol.Optional("min_group_size", default=2): vol.All(cv.positive_int, vol.Range(min=2)),
             vol.Optional("overwrite_existing", default=True): cv.boolean,
         }, extra=vol.ALLOW_EXTRA),
         supports_response=SupportsResponse.ONLY,

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -1922,28 +1922,23 @@ class CacheManager:
 
         groups_found = 0
         files_updated = 0
-        files_skipped = 0
         errors = 0
-        pending_writes: list[tuple] = []  # (favorites_json, burst_count, path)
+        pending_writes: list[tuple] = []  # (favorites_json, burst_count, file_id)
         current_group: list = []
 
         async def _flush_writes():
             nonlocal files_updated, files_skipped, errors
-            for favorites_json, burst_count, path in pending_writes:
-                try:
-                    async with self._db.execute(
-                        """UPDATE exif_data
-                               SET burst_favorites = ?, burst_count = ?
-                             WHERE file_id = (SELECT id FROM media_files WHERE path = ?)""",
-                        (favorites_json, burst_count, path),
-                    ) as upd_cursor:
-                        if upd_cursor.rowcount > 0:
-                            files_updated += 1
-                        else:
-                            files_skipped += 1
-                except Exception as exc:
-                    _LOGGER.warning("index_burst_groups: error updating %s: %s", path, exc)
-                    errors += 1
+            if not pending_writes:
+                return
+            try:
+                await self._db.executemany(
+                    "UPDATE exif_data SET burst_favorites = ?, burst_count = ? WHERE file_id = ?",
+                    pending_writes,
+                )
+                files_updated += len(pending_writes)
+            except Exception as exc:
+                _LOGGER.warning("index_burst_groups: batch update error: %s", exc)
+                errors += len(pending_writes)
             await self._db.commit()
             pending_writes.clear()
 
@@ -1961,7 +1956,7 @@ class CacheManager:
                 favorited_filenames = [r["filename"] for r in cluster if r.get("is_favorited")]
                 favorites_json = json.dumps(favorited_filenames) if favorited_filenames else None
                 for row in cluster:
-                    pending_writes.append((favorites_json, burst_count, row["path"]))
+                    pending_writes.append((favorites_json, burst_count, row["file_id"]))
 
             if len(pending_writes) >= WRITE_BATCH_SIZE:
                 await _flush_writes()
@@ -2008,12 +2003,12 @@ class CacheManager:
 
         _LOGGER.info(
             "index_burst_groups: done — groups=%d, updated=%d, skipped=%d, errors=%d",
-            groups_found, files_updated, files_skipped, errors,
+            groups_found, files_updated, total_rows_seen - files_updated, errors,
         )
         return {
             "groups_found": groups_found,
             "files_updated": files_updated,
-            "files_skipped": files_skipped,
+            "files_skipped": total_rows_seen - files_updated,
             "errors": errors,
         }
 

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -801,7 +801,8 @@ class CacheManager:
         anniversary_window_days: int = 0,
         favorites_only: bool = False,
         priority_new_files: bool = False,
-        new_files_threshold_seconds: int = 3600
+        new_files_threshold_seconds: int = 3600,
+        auto_select_burst_favorite: bool = False
     ) -> list[dict]:
         """Get random media files with optional filters and EXIF data.
         
@@ -851,6 +852,8 @@ class CacheManager:
                     e.location_state,
                     e.location_country,
                     e.is_favorited,
+                    e.burst_count,
+                    e.burst_favorites,
                     e.camera_make,
                     e.camera_model
                 FROM media_files m
@@ -877,6 +880,17 @@ class CacheManager:
             
             if favorites_only:
                 new_files_query += " AND e.is_favorited = 1"
+
+            if auto_select_burst_favorite:
+                # Exclude non-favorite members of burst groups that have a known favorite.
+                # Items with burst_count IS NULL are not part of any burst — returned as normal.
+                # Items in a burst group with no favorites (burst_favorites IS NULL) are also
+                # returned normally (nothing better to show).
+                new_files_query += (
+                    " AND NOT (e.burst_count > 0"
+                    " AND COALESCE(e.is_favorited, 0) = 0"
+                    " AND e.burst_favorites IS NOT NULL)"
+                )
             
             # Timestamp filtering (takes precedence over date filtering)
             if timestamp_from is not None:
@@ -985,7 +999,8 @@ class CacheManager:
                     anniversary_month=anniversary_month,
                     anniversary_day=anniversary_day,
                     anniversary_window_days=anniversary_window_days,
-                    favorites_only=favorites_only
+                    favorites_only=favorites_only,
+                    auto_select_burst_favorite=auto_select_burst_favorite
                 )
                 result = new_files + random_files
             else:
@@ -1012,6 +1027,8 @@ class CacheManager:
                     e.location_state,
                     e.location_country,
                     e.is_favorited,
+                    e.burst_count,
+                    e.burst_favorites,
                     e.camera_make,
                     e.camera_model
                 FROM media_files m
@@ -1039,6 +1056,17 @@ class CacheManager:
             
             if favorites_only:
                 query += " AND e.is_favorited = 1"
+
+            if auto_select_burst_favorite:
+                # Exclude non-favorite members of burst groups that have a known favorite.
+                # Items with burst_count IS NULL are not part of any burst — returned as normal.
+                # Items in a burst group with no favorites (burst_favorites IS NULL) are also
+                # returned normally (nothing better to show).
+                query += (
+                    " AND NOT (e.burst_count > 0"
+                    " AND COALESCE(e.is_favorited, 0) = 0"
+                    " AND e.burst_favorites IS NOT NULL)"
+                )
             
             # Timestamp filtering (takes precedence over date filtering)
             if timestamp_from is not None:
@@ -1141,7 +1169,8 @@ class CacheManager:
         anniversary_month: str | None = None,
         anniversary_day: str | None = None,
         anniversary_window_days: int = 0,
-        favorites_only: bool = False
+        favorites_only: bool = False,
+        auto_select_burst_favorite: bool = False
     ) -> list[dict]:
         """Get random files excluding specified IDs (helper for priority queue).
         
@@ -1210,6 +1239,13 @@ class CacheManager:
         
         if favorites_only:
             query += " AND e.is_favorited = 1"
+
+        if auto_select_burst_favorite:
+            query += (
+                " AND NOT (e.burst_count > 0"
+                " AND COALESCE(e.is_favorited, 0) = 0"
+                " AND e.burst_favorites IS NOT NULL)"
+            )
         
         # Timestamp filtering (takes precedence over date filtering)
         if timestamp_from is not None:

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -1811,7 +1811,33 @@ class CacheManager:
         )
 
         # ------------------------------------------------------------------
-        # 1. Load all candidate rows (one query, sorted)
+        # 1. Clear stale burst data for all in-scope files (overwrite mode only)
+        #
+        # Without this, files previously in a large group (e.g. 15 s window) keep
+        # their old burst_count when re-indexed with a narrower window — causing the
+        # metadata header to show the old count while the live panel query finds fewer.
+        # ------------------------------------------------------------------
+        if overwrite_existing:
+            clear_where = (
+                "WHERE file_id IN ("
+                "  SELECT e.file_id FROM exif_data e"
+                "  JOIN media_files m ON m.id = e.file_id"
+                "  WHERE e.date_taken IS NOT NULL"
+            )
+            clear_params: list = []
+            if folder:
+                clear_where += "  AND m.folder LIKE ?"
+                clear_params.append(folder.rstrip("/") + "%")
+            clear_where += ")"
+            await self._db.execute(
+                f"UPDATE exif_data SET burst_count = NULL, burst_favorites = NULL {clear_where}",
+                clear_params,
+            )
+            await self._db.commit()
+            _LOGGER.debug("index_burst_groups: cleared stale burst data for scope (folder=%s)", folder or "all")
+
+        # ------------------------------------------------------------------
+        # 2. Load all candidate rows (one query, sorted)
         # ------------------------------------------------------------------
         where_clause = "WHERE e.date_taken IS NOT NULL"
         params: list = []

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -1392,7 +1392,7 @@ class CacheManager:
             "date_taken": "COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time)))",
             "filename": "m.filename",
             "path": "m.folder || '/' || m.filename",
-            "modified_time": "m.modified_time",
+            "modified_time": "unixepoch(m.modified_time)",
         }
         allowed_directions = {
             "asc": "ASC",
@@ -1796,8 +1796,8 @@ class CacheManager:
             location_tolerance_meters: GPS cluster radius in metres (default 50 m).
             min_group_size:           Minimum photos to constitute a burst group (default 2).
             overwrite_existing:       If False, skip files that already have burst_count set.
-            progress_callback:        Optional async callable(groups_found, files_processed)
-                                      called every 500 files processed.
+            progress_callback:        Optional async callable(groups_found, files_updated)
+                                      called when a write batch is flushed.
 
         Returns:
             Dict with keys: groups_found, files_updated, files_skipped, errors

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -887,14 +887,14 @@ class CacheManager:
                 # Items in a burst group with no favorites (burst_favorites IS NULL) are also
                 # returned normally (nothing better to show).
                 new_files_query += (
-                    " AND NOT (e.burst_count > 0"
+                    " AND NOT (COALESCE(e.burst_count, 0) > 0"
                     " AND COALESCE(e.is_favorited, 0) = 0"
                     " AND e.burst_favorites IS NOT NULL)"
                 )
             
             # Timestamp filtering (takes precedence over date filtering)
             if timestamp_from is not None:
-                new_files_query += " AND COALESCE(e.date_taken, m.created_time) >= ?"
+                new_files_query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) >= ?"
                 params.append(timestamp_from)
             elif date_from is not None:
                 # Validate date_from is a valid date string using datetime.strptime
@@ -904,13 +904,13 @@ class CacheManager:
                     dt = datetime.strptime(date_from_str, "%Y-%m-%d")
                     # Convert to Unix timestamp using server local time (matches how EXIF timestamps are stored)
                     timestamp = int(dt.timestamp())
-                    new_files_query += " AND COALESCE(e.date_taken, m.created_time) >= ?"
+                    new_files_query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) >= ?"
                     params.append(timestamp)
                 except (ValueError, TypeError) as e:
                     _LOGGER.warning("Invalid date_from parameter: %s - %s", date_from, e)
             
             if timestamp_to is not None:
-                new_files_query += " AND COALESCE(e.date_taken, m.created_time) <= ?"
+                new_files_query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) <= ?"
                 params.append(timestamp_to)
             elif date_to is not None:
                 # Validate date_to is a valid date string using datetime.strptime
@@ -920,7 +920,7 @@ class CacheManager:
                     dt = datetime.strptime(date_to_str, "%Y-%m-%d")
                     # Convert to Unix timestamp using server local time (end of local day = start of next day minus 1)
                     timestamp = int((dt + timedelta(days=1)).timestamp()) - 1
-                    new_files_query += " AND COALESCE(e.date_taken, m.created_time) <= ?"
+                    new_files_query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) <= ?"
                     params.append(timestamp)
                 except (ValueError, TypeError) as e:
                     _LOGGER.warning("Invalid date_to parameter: %s - %s", date_to, e)
@@ -937,11 +937,11 @@ class CacheManager:
                             # Generate day range with window
                             day_min = max(1, day_int - anniversary_window_days)
                             day_max = min(31, day_int + anniversary_window_days)
-                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) BETWEEN ? AND ?")
+                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) BETWEEN ? AND ?")
                             params.extend([day_min, day_max])
                         else:
                             # Exact day match
-                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) = ?")
+                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) = ?")
                             params.append(day_int)
                     except ValueError:
                         _LOGGER.warning("Invalid anniversary_day parameter: %s", anniversary_day)
@@ -951,7 +951,7 @@ class CacheManager:
                 if anniversary_month and anniversary_month != "*":
                     try:
                         month_int = int(anniversary_month)
-                        ann_conditions.append("CAST(strftime('%m', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) = ?")
+                        ann_conditions.append("CAST(strftime('%m', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) = ?")
                         params.append(month_int)
                     except ValueError:
                         _LOGGER.warning("Invalid anniversary_month parameter: %s", anniversary_month)
@@ -1063,14 +1063,14 @@ class CacheManager:
                 # Items in a burst group with no favorites (burst_favorites IS NULL) are also
                 # returned normally (nothing better to show).
                 query += (
-                    " AND NOT (e.burst_count > 0"
+                    " AND NOT (COALESCE(e.burst_count, 0) > 0"
                     " AND COALESCE(e.is_favorited, 0) = 0"
                     " AND e.burst_favorites IS NOT NULL)"
                 )
             
             # Timestamp filtering (takes precedence over date filtering)
             if timestamp_from is not None:
-                query += " AND COALESCE(e.date_taken, m.created_time) >= ?"
+                query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) >= ?"
                 params.append(timestamp_from)
             elif date_from is not None:
                 # Validate date_from is a valid date string using datetime.strptime
@@ -1080,13 +1080,13 @@ class CacheManager:
                     dt = datetime.strptime(date_from_str, "%Y-%m-%d")
                     # Convert to Unix timestamp using server local time (matches how EXIF timestamps are stored)
                     timestamp = int(dt.timestamp())
-                    query += " AND COALESCE(e.date_taken, m.created_time) >= ?"
+                    query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) >= ?"
                     params.append(timestamp)
                 except (ValueError, TypeError) as e:
                     _LOGGER.warning("Invalid date_from parameter: %s - %s", date_from, e)
             
             if timestamp_to is not None:
-                query += " AND COALESCE(e.date_taken, m.created_time) <= ?"
+                query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) <= ?"
                 params.append(timestamp_to)
             elif date_to is not None:
                 # Validate date_to is a valid date string using datetime.strptime
@@ -1096,7 +1096,7 @@ class CacheManager:
                     dt = datetime.strptime(date_to_str, "%Y-%m-%d")
                     # Convert to Unix timestamp using server local time (end of local day = start of next day minus 1)
                     timestamp = int((dt + timedelta(days=1)).timestamp()) - 1
-                    query += " AND COALESCE(e.date_taken, m.created_time) <= ?"
+                    query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) <= ?"
                     params.append(timestamp)
                 except (ValueError, TypeError) as e:
                     _LOGGER.warning("Invalid date_to parameter: %s - %s", date_to, e)
@@ -1113,11 +1113,11 @@ class CacheManager:
                             # Generate day range with window
                             day_min = max(1, day_int - anniversary_window_days)
                             day_max = min(31, day_int + anniversary_window_days)
-                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) BETWEEN ? AND ?")
+                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) BETWEEN ? AND ?")
                             params.extend([day_min, day_max])
                         else:
                             # Exact day match
-                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) = ?")
+                            ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) = ?")
                             params.append(day_int)
                     except ValueError:
                         _LOGGER.warning("Invalid anniversary_day parameter: %s", anniversary_day)
@@ -1127,7 +1127,7 @@ class CacheManager:
                 if anniversary_month and anniversary_month != "*":
                     try:
                         month_int = int(anniversary_month)
-                        ann_conditions.append("CAST(strftime('%m', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) = ?")
+                        ann_conditions.append("CAST(strftime('%m', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) = ?")
                         params.append(month_int)
                     except ValueError:
                         _LOGGER.warning("Invalid anniversary_month parameter: %s", anniversary_month)
@@ -1242,14 +1242,14 @@ class CacheManager:
 
         if auto_select_burst_favorite:
             query += (
-                " AND NOT (e.burst_count > 0"
+                " AND NOT (COALESCE(e.burst_count, 0) > 0"
                 " AND COALESCE(e.is_favorited, 0) = 0"
                 " AND e.burst_favorites IS NOT NULL)"
             )
         
         # Timestamp filtering (takes precedence over date filtering)
         if timestamp_from is not None:
-            query += " AND COALESCE(e.date_taken, m.created_time) >= ?"
+            query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) >= ?"
             params.append(timestamp_from)
         elif date_from is not None:
             # Validate date_from is a valid date string
@@ -1258,13 +1258,13 @@ class CacheManager:
                 dt = datetime.strptime(date_from_str, "%Y-%m-%d")
                 # Convert to Unix timestamp using server local time (matches how EXIF timestamps are stored)
                 timestamp = int(dt.timestamp())
-                query += " AND COALESCE(e.date_taken, m.created_time) >= ?"
+                query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) >= ?"
                 params.append(timestamp)
             except (ValueError, TypeError) as e:
                 _LOGGER.warning("Invalid date_from parameter: %s - %s", date_from, e)
         
         if timestamp_to is not None:
-            query += " AND COALESCE(e.date_taken, m.created_time) <= ?"
+            query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) <= ?"
             params.append(timestamp_to)
         elif date_to is not None:
             # Validate date_to is a valid date string
@@ -1273,7 +1273,7 @@ class CacheManager:
                 dt = datetime.strptime(date_to_str, "%Y-%m-%d")
                 # Convert to Unix timestamp using server local time (end of local day = start of next day minus 1)
                 timestamp = int((dt + timedelta(days=1)).timestamp()) - 1
-                query += " AND COALESCE(e.date_taken, m.created_time) <= ?"
+                query += " AND COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))) <= ?"
                 params.append(timestamp)
             except (ValueError, TypeError) as e:
                 _LOGGER.warning("Invalid date_to parameter: %s - %s", date_to, e)
@@ -1289,10 +1289,10 @@ class CacheManager:
                     if anniversary_window_days > 0:
                         day_min = max(1, day_int - anniversary_window_days)
                         day_max = min(31, day_int + anniversary_window_days)
-                        ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) BETWEEN ? AND ?")
+                        ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) BETWEEN ? AND ?")
                         params.extend([day_min, day_max])
                     else:
-                        ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) = ?")
+                        ann_conditions.append("CAST(strftime('%d', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) = ?")
                         params.append(day_int)
                 except ValueError:
                     _LOGGER.warning("Invalid anniversary_day parameter: %s", anniversary_day)
@@ -1301,7 +1301,7 @@ class CacheManager:
             if anniversary_month and anniversary_month != "*":
                 try:
                     month_int = int(anniversary_month)
-                    ann_conditions.append("CAST(strftime('%m', COALESCE(e.date_taken, m.created_time), 'unixepoch', 'localtime') AS INTEGER) = ?")
+                    ann_conditions.append("CAST(strftime('%m', COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time))), 'unixepoch', 'localtime') AS INTEGER) = ?")
                     params.append(month_int)
                 except ValueError:
                     _LOGGER.warning("Invalid anniversary_month parameter: %s", anniversary_month)
@@ -1389,7 +1389,7 @@ class CacheManager:
         
         # Use explicit whitelist mapping for sort fields and directions
         allowed_sort_fields = {
-            "date_taken": "COALESCE(e.date_taken, m.modified_time)",
+            "date_taken": "COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time)))",
             "filename": "m.filename",
             "path": "m.folder || '/' || m.filename",
             "modified_time": "m.modified_time",
@@ -1398,7 +1398,7 @@ class CacheManager:
             "asc": "ASC",
             "desc": "DESC",
         }
-        sort_field = allowed_sort_fields.get(order_by, "COALESCE(e.date_taken, m.modified_time)")
+        sort_field = allowed_sort_fields.get(order_by, "COALESCE(e.date_taken, MIN(unixepoch(m.created_time), unixepoch(m.modified_time)))")
         direction = allowed_directions.get(order_direction.lower(), "DESC")
         
         # v1.5.10: Compound cursor pagination using (sort_field, id)
@@ -1523,7 +1523,7 @@ class CacheManager:
 
         reference_latitude = exif_data.get('latitude')
         reference_longitude = exif_data.get('longitude')
-        use_location = bool(reference_latitude and reference_longitude and prefer_same_location)
+        use_location = bool(reference_latitude is not None and reference_longitude is not None and prefer_same_location)
 
         _LOGGER.info(
             "Burst detection: ref_date=%s, location_present=%s, window=%ds",

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -1448,14 +1448,23 @@ class CacheManager:
         sort_order: str = "time_asc"
     ) -> list[dict]:
         """Get burst photos taken near the same time as a reference photo.
-        
+
+        Uses iterative range expansion to find the complete burst group regardless
+        of which photo in the burst is used as the reference. After each query the
+        search range is widened to [min_found - window, max_found + window] and the
+        query is repeated until no new paths appear. This guarantees that a photo
+        near either edge of the burst still returns the full group.
+
+        The seconds_offset column and GPS filter are always anchored to the original
+        reference photo so results remain comparable across different reference choices.
+
         Args:
             reference_path: Path to the reference photo
-            time_window_seconds: Time window in seconds (default: 10)
-            prefer_same_location: Prioritize photos at same GPS location (default: True)
+            time_window_seconds: Maximum gap in seconds between consecutive burst photos (default: 10)
+            prefer_same_location: Only include photos at the same GPS location (default: True)
             location_tolerance_meters: GPS tolerance in meters (default: 50)
             sort_order: Sort order - 'time_asc' or 'time_desc' (default: time_asc)
-            
+
         Returns:
             List of burst photos with metadata
         """
@@ -1464,29 +1473,32 @@ class CacheManager:
         if not reference_file:
             _LOGGER.error("Reference file not found: %s", reference_path)
             return []
-        
+
         # Extract EXIF data from nested object
         exif_data = reference_file.get('exif', {})
         if not exif_data:
             _LOGGER.error("Reference file has no EXIF data: %s", reference_path)
             return []
-        
+
         reference_date_taken = exif_data.get('date_taken')
         if not reference_date_taken:
             _LOGGER.error("Reference file has no date_taken in EXIF: %s", reference_path)
             return []
-        
+
         reference_latitude = exif_data.get('latitude')
         reference_longitude = exif_data.get('longitude')
-        
+        use_location = bool(reference_latitude and reference_longitude and prefer_same_location)
+
         _LOGGER.info(
             "Burst detection: ref_date=%s, location_present=%s, window=%ds",
-            reference_date_taken, reference_latitude is not None and reference_longitude is not None, time_window_seconds
+            reference_date_taken, use_location, time_window_seconds
         )
-        
-        # Build query
-        query = """
-            SELECT 
+
+        # Build base SELECT. seconds_offset is always relative to the original reference
+        # so the caller gets consistent timing deltas regardless of which iteration found
+        # a given photo.
+        base_query = """
+            SELECT
                 m.id,
                 m.path,
                 m.filename,
@@ -1506,63 +1518,92 @@ class CacheManager:
                 e.rating,
                 (e.date_taken - ?) AS seconds_offset
         """
-        
-        # Add GPS distance calculation if location available
-        if reference_latitude and reference_longitude and prefer_same_location:
-            query += f""",
+
+        if use_location:
+            base_query += """,
                 (6371000 * acos(
                     cos(radians(?)) * cos(radians(e.latitude)) *
                     cos(radians(e.longitude) - radians(?)) +
                     sin(radians(?)) * sin(radians(e.latitude))
                 )) AS distance_meters
             """
-        
-        query += """
+
+        base_query += """
             FROM media_files m
             JOIN exif_data e ON m.id = e.file_id
             WHERE e.date_taken IS NOT NULL
-              AND ABS(e.date_taken - ?) <= ?
+              AND e.date_taken BETWEEN ? AND ?
         """
-        
-        # Add location filter if applicable
-        if reference_latitude and reference_longitude and prefer_same_location:
-            query += f"""
+
+        if use_location:
+            base_query += """
               AND (6371000 * acos(
                   cos(radians(?)) * cos(radians(e.latitude)) *
                   cos(radians(e.longitude) - radians(?)) +
                   sin(radians(?)) * sin(radians(e.latitude))
               )) <= ?
             """
-        
-        # Add sorting
+
         if sort_order == "time_desc":
-            query += " ORDER BY e.date_taken DESC"
+            base_query += " ORDER BY e.date_taken DESC"
         else:
-            query += " ORDER BY e.date_taken ASC"
-        
-        # Build parameters
-        params = [reference_date_taken]
-        
-        if reference_latitude and reference_longitude and prefer_same_location:
-            params.extend([reference_latitude, reference_longitude, reference_latitude])
-        
-        params.extend([reference_date_taken, time_window_seconds])
-        
-        if reference_latitude and reference_longitude and prefer_same_location:
-            params.extend([
-                reference_latitude,
-                reference_longitude,
-                reference_latitude,
-                location_tolerance_meters
-            ])
-        
-        # Execute query
-        _LOGGER.debug("Burst query params: %s", params)
-        async with self._db.execute(query, params) as cursor:
-            rows = await cursor.fetchall()
-        
-        _LOGGER.debug("Burst query returned %d rows", len(rows))
-        return [dict(row) for row in rows]
+            base_query += " ORDER BY e.date_taken ASC"
+
+        # Iterative expansion: start with ±window around the reference timestamp,
+        # then widen to cover the earliest/latest found photo each time new photos appear.
+        range_min = reference_date_taken - time_window_seconds
+        range_max = reference_date_taken + time_window_seconds
+        found_paths: set = set()
+        result_rows: list = []
+        max_iterations = 20
+
+        for iteration in range(max_iterations):
+            # seconds_offset anchor is always the original reference
+            params = [reference_date_taken]
+            if use_location:
+                params.extend([reference_latitude, reference_longitude, reference_latitude])
+            params.extend([range_min, range_max])
+            if use_location:
+                params.extend([
+                    reference_latitude,
+                    reference_longitude,
+                    reference_latitude,
+                    location_tolerance_meters
+                ])
+
+            _LOGGER.debug(
+                "Burst query iteration %d: range=[%s, %s]",
+                iteration + 1, range_min, range_max
+            )
+            async with self._db.execute(base_query, params) as cursor:
+                rows = await cursor.fetchall()
+
+            row_dicts = [dict(row) for row in rows]
+            new_paths = {r['path'] for r in row_dicts} - found_paths
+
+            if not new_paths:
+                _LOGGER.debug(
+                    "Burst detection converged after %d iteration(s), %d photos",
+                    iteration + 1, len(result_rows)
+                )
+                break
+
+            # Absorb the newly found photos and widen the search range
+            found_paths |= new_paths
+            result_rows = row_dicts
+
+            all_times = [r['date_taken'] for r in row_dicts if r.get('date_taken')]
+            if all_times:
+                range_min = min(all_times) - time_window_seconds
+                range_max = max(all_times) + time_window_seconds
+        else:
+            _LOGGER.warning(
+                "Burst detection hit max iterations (%d) for %s",
+                max_iterations, reference_path
+            )
+
+        _LOGGER.debug("Burst query returned %d rows (stable)", len(result_rows))
+        return result_rows
     
     async def get_file_by_id(self, file_id: int) -> dict | None:
         """Get file metadata by database ID.
@@ -1682,6 +1723,233 @@ class CacheManager:
         
         return updated_count
     
+    async def index_burst_groups(
+        self,
+        folder: str | None = None,
+        time_window_seconds: int = 10,
+        location_tolerance_meters: int = 50,
+        min_group_size: int = 2,
+        overwrite_existing: bool = True,
+        progress_callback=None,
+    ) -> dict:
+        """Scan the library and write burst_count / burst_favorites to every file in every
+        detected burst group.
+
+        Algorithm (O(n log n)):
+          1. Fetch all rows with date_taken (+ optional GPS), ordered by date_taken ASC.
+          2. Walk the sorted list: consecutive photos within time_window_seconds form a group.
+             When the gap exceeds the window, the current group is finalised.
+          3. GPS sub-clustering: when GPS is present for every member of a group, split the
+             group into GPS clusters (using the same location_tolerance_meters radius).
+             Photos without GPS are placed in their own temporal-only sub-group.
+          4. Groups with fewer than min_group_size photos are ignored.
+          5. bust_count = total members; burst_favorites = JSON list of filenames of
+             members where is_favorited = 1.
+          6. Write results in batches of 500 to keep memory flat over large libraries.
+
+        Scale notes:
+          - Designed for 200 K+ item libraries.
+          - Uses a single sorted SELECT with no per-file round-trips.
+          - Commit frequency: every 500 rows updated to avoid holding a large transaction.
+
+        Args:
+            folder:                   Only process files under this folder prefix (None = all).
+            time_window_seconds:      Maximum gap between consecutive burst photos (default 10 s).
+            location_tolerance_meters: GPS cluster radius in metres (default 50 m).
+            min_group_size:           Minimum photos to constitute a burst group (default 2).
+            overwrite_existing:       If False, skip files that already have burst_count set.
+            progress_callback:        Optional async callable(groups_found, files_processed)
+                                      called every 500 files processed.
+
+        Returns:
+            Dict with keys: groups_found, files_updated, files_skipped, errors
+        """
+        import json
+        import math
+
+        _LOGGER.info(
+            "index_burst_groups: starting (folder=%s, window=%ds, location=%dm, min=%d)",
+            folder or "all", time_window_seconds, location_tolerance_meters, min_group_size
+        )
+
+        # ------------------------------------------------------------------
+        # 1. Load all candidate rows (one query, sorted)
+        # ------------------------------------------------------------------
+        where_clause = "WHERE e.date_taken IS NOT NULL"
+        params: list = []
+        if folder:
+            where_clause += " AND m.folder LIKE ?"
+            params.append(folder.rstrip("/") + "%")
+        if not overwrite_existing:
+            where_clause += " AND (e.burst_count IS NULL OR e.burst_count = 0)"
+
+        query = f"""
+            SELECT
+                m.path,
+                m.filename,
+                e.date_taken,
+                e.latitude,
+                e.longitude,
+                e.is_favorited,
+                e.file_id
+            FROM media_files m
+            JOIN exif_data e ON m.id = e.file_id
+            {where_clause}
+            ORDER BY e.date_taken ASC
+        """
+
+        async with self._db.execute(query, params) as cursor:
+            rows = await cursor.fetchall()
+
+        total_rows = len(rows)
+        _LOGGER.info("index_burst_groups: loaded %d candidate rows", total_rows)
+
+        if total_rows == 0:
+            return {"groups_found": 0, "files_updated": 0, "files_skipped": 0, "errors": 0}
+
+        # ------------------------------------------------------------------
+        # 2. Temporal grouping (sorted walk)
+        # ------------------------------------------------------------------
+        def _gps_distance_m(lat1, lon1, lat2, lon2):
+            """Haversine distance in metres between two GPS points."""
+            R = 6_371_000
+            φ1, φ2 = math.radians(lat1), math.radians(lat2)
+            dφ = math.radians(lat2 - lat1)
+            dλ = math.radians(lon2 - lon1)
+            a = math.sin(dφ / 2) ** 2 + math.cos(φ1) * math.cos(φ2) * math.sin(dλ / 2) ** 2
+            return R * 2 * math.asin(math.sqrt(a))
+
+        def _gps_cluster(members):
+            """Split a temporal group into GPS sub-clusters.
+
+            Members without GPS are put in a single no-GPS cluster.
+            Members with GPS are greedily assigned to the first existing cluster whose
+            centroid is within location_tolerance_meters, otherwise start a new cluster.
+            Returns a list of member-lists.
+            """
+            gps_clusters: list[list] = []   # [[row, ...], ...]
+            centroids: list[tuple] = []      # [(lat, lon), ...]
+            no_gps: list = []
+
+            for row in members:
+                lat, lon = row["latitude"], row["longitude"]
+                if lat is None or lon is None:
+                    no_gps.append(row)
+                    continue
+
+                assigned = False
+                for idx, (clat, clon) in enumerate(centroids):
+                    if _gps_distance_m(lat, lon, clat, clon) <= location_tolerance_meters:
+                        gps_clusters[idx].append(row)
+                        # Update centroid as running mean
+                        n = len(gps_clusters[idx])
+                        centroids[idx] = (
+                            clat + (lat - clat) / n,
+                            clon + (lon - clon) / n,
+                        )
+                        assigned = True
+                        break
+                if not assigned:
+                    gps_clusters.append([row])
+                    centroids.append((lat, lon))
+
+            result = [c for c in gps_clusters if c]  # non-empty GPS clusters
+            if no_gps:
+                result.append(no_gps)
+            return result
+
+        # Group rows into temporal bursts
+        temporal_groups: list[list] = []
+        current_group: list = [dict(rows[0])]
+
+        for i in range(1, len(rows)):
+            row = dict(rows[i])
+            prev_time = current_group[-1]["date_taken"]
+            curr_time = row["date_taken"]
+            if curr_time is not None and prev_time is not None and (curr_time - prev_time) <= time_window_seconds:
+                current_group.append(row)
+            else:
+                temporal_groups.append(current_group)
+                current_group = [row]
+        temporal_groups.append(current_group)
+
+        # Sub-cluster each temporal group by GPS
+        burst_groups: list[list] = []
+        for tg in temporal_groups:
+            if any(r.get("latitude") is not None for r in tg):
+                for cluster in _gps_cluster(tg):
+                    burst_groups.append(cluster)
+            else:
+                burst_groups.append(tg)
+
+        # Filter by minimum size
+        burst_groups = [g for g in burst_groups if len(g) >= min_group_size]
+
+        _LOGGER.info("index_burst_groups: found %d burst groups (>= %d photos)", len(burst_groups), min_group_size)
+
+        # ------------------------------------------------------------------
+        # 3. Write results in batches
+        # ------------------------------------------------------------------
+        groups_found = len(burst_groups)
+        files_updated = 0
+        files_skipped = 0
+        errors = 0
+        batch_writes: list[tuple] = []  # (favorites_json, burst_count, path)
+
+        for group in burst_groups:
+            burst_count = len(group)
+            favorited_filenames = [
+                r["filename"] for r in group if r.get("is_favorited")
+            ]
+            favorites_json = json.dumps(favorited_filenames) if favorited_filenames else None
+
+            for row in group:
+                batch_writes.append((favorites_json, burst_count, row["path"]))
+
+        # Execute in batches of 500
+        BATCH_SIZE = 500
+        for batch_start in range(0, len(batch_writes), BATCH_SIZE):
+            batch = batch_writes[batch_start: batch_start + BATCH_SIZE]
+            for favorites_json, burst_count, path in batch:
+                try:
+                    async with self._db.execute(
+                        """UPDATE exif_data
+                               SET burst_favorites = ?, burst_count = ?
+                             WHERE file_id = (SELECT id FROM media_files WHERE path = ?)""",
+                        (favorites_json, burst_count, path),
+                    ) as cursor:
+                        if cursor.rowcount > 0:
+                            files_updated += 1
+                        else:
+                            files_skipped += 1
+                except Exception as exc:
+                    _LOGGER.warning("index_burst_groups: error updating %s: %s", path, exc)
+                    errors += 1
+
+            await self._db.commit()
+
+            processed_so_far = min(batch_start + BATCH_SIZE, len(batch_writes))
+            _LOGGER.debug(
+                "index_burst_groups: committed batch (%d/%d rows written)",
+                processed_so_far, len(batch_writes)
+            )
+            if progress_callback:
+                try:
+                    await progress_callback(groups_found, processed_so_far)
+                except Exception:
+                    pass
+
+        _LOGGER.info(
+            "index_burst_groups: done — groups=%d, updated=%d, skipped=%d, errors=%d",
+            groups_found, files_updated, files_skipped, errors,
+        )
+        return {
+            "groups_found": groups_found,
+            "files_updated": files_updated,
+            "files_skipped": files_skipped,
+            "errors": errors,
+        }
+
     async def delete_file(self, file_path: str) -> bool:
         """Delete file record from database.
         

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -1772,21 +1772,23 @@ class CacheManager:
         detected burst group.
 
         Algorithm (O(n log n)):
-          1. Fetch all rows with date_taken (+ optional GPS), ordered by date_taken ASC.
-          2. Walk the sorted list: consecutive photos within time_window_seconds form a group.
-             When the gap exceeds the window, the current group is finalised.
-          3. GPS sub-clustering: when GPS is present for every member of a group, split the
+          1. Stream rows with date_taken (+ optional GPS), ordered by date_taken ASC,
+             fetching FETCH_SIZE rows at a time — never loading the full library into memory.
+          2. Walk the stream: consecutive photos within time_window_seconds form a group.
+             When the gap exceeds the window, the current group is finalised immediately.
+          3. GPS sub-clustering: when GPS is present for any member of a group, split the
              group into GPS clusters (using the same location_tolerance_meters radius).
              Photos without GPS are placed in their own temporal-only sub-group.
           4. Groups with fewer than min_group_size photos are ignored.
-          5. bust_count = total members; burst_favorites = JSON list of filenames of
+          5. burst_count = total members; burst_favorites = JSON list of filenames of
              members where is_favorited = 1.
-          6. Write results in batches of 500 to keep memory flat over large libraries.
+          6. Write results in batches of WRITE_BATCH_SIZE to keep transactions short.
 
         Scale notes:
           - Designed for 200 K+ item libraries.
           - Uses a single sorted SELECT with no per-file round-trips.
-          - Commit frequency: every 500 rows updated to avoid holding a large transaction.
+          - Memory footprint: O(burst_size) — at most one temporal group in memory at a time.
+          - Commit frequency: every WRITE_BATCH_SIZE rows updated to avoid large transactions.
 
         Args:
             folder:                   Only process files under this folder prefix (None = all).
@@ -1834,17 +1836,10 @@ class CacheManager:
             ORDER BY e.date_taken ASC
         """
 
-        async with self._db.execute(query, params) as cursor:
-            rows = await cursor.fetchall()
-
-        total_rows = len(rows)
-        _LOGGER.info("index_burst_groups: loaded %d candidate rows", total_rows)
-
-        if total_rows == 0:
-            return {"groups_found": 0, "files_updated": 0, "files_skipped": 0, "errors": 0}
+        total_rows_seen = 0
 
         # ------------------------------------------------------------------
-        # 2. Temporal grouping (sorted walk)
+        # 2. Helper: GPS sub-clustering
         # ------------------------------------------------------------------
         def _gps_distance_m(lat1, lon1, lat2, lon2):
             """Haversine distance in metres between two GPS points."""
@@ -1863,8 +1858,8 @@ class CacheManager:
             centroid is within location_tolerance_meters, otherwise start a new cluster.
             Returns a list of member-lists.
             """
-            gps_clusters: list[list] = []   # [[row, ...], ...]
-            centroids: list[tuple] = []      # [(lat, lon), ...]
+            gps_clusters: list[list] = []
+            centroids: list[tuple] = []
             no_gps: list = []
 
             for row in members:
@@ -1877,7 +1872,6 @@ class CacheManager:
                 for idx, (clat, clon) in enumerate(centroids):
                     if _gps_distance_m(lat, lon, clat, clon) <= location_tolerance_meters:
                         gps_clusters[idx].append(row)
-                        # Update centroid as running mean
                         n = len(gps_clusters[idx])
                         centroids[idx] = (
                             clat + (lat - clat) / n,
@@ -1889,91 +1883,102 @@ class CacheManager:
                     gps_clusters.append([row])
                     centroids.append((lat, lon))
 
-            result = [c for c in gps_clusters if c]  # non-empty GPS clusters
+            result = [c for c in gps_clusters if c]
             if no_gps:
                 result.append(no_gps)
             return result
 
-        # Group rows into temporal bursts
-        temporal_groups: list[list] = []
-        current_group: list = [dict(rows[0])]
-
-        for i in range(1, len(rows)):
-            row = dict(rows[i])
-            prev_time = current_group[-1]["date_taken"]
-            curr_time = row["date_taken"]
-            if curr_time is not None and prev_time is not None and (curr_time - prev_time) <= time_window_seconds:
-                current_group.append(row)
-            else:
-                temporal_groups.append(current_group)
-                current_group = [row]
-        temporal_groups.append(current_group)
-
-        # Sub-cluster each temporal group by GPS
-        burst_groups: list[list] = []
-        for tg in temporal_groups:
-            if any(r.get("latitude") is not None for r in tg):
-                for cluster in _gps_cluster(tg):
-                    burst_groups.append(cluster)
-            else:
-                burst_groups.append(tg)
-
-        # Filter by minimum size
-        burst_groups = [g for g in burst_groups if len(g) >= min_group_size]
-
-        _LOGGER.info("index_burst_groups: found %d burst groups (>= %d photos)", len(burst_groups), min_group_size)
-
         # ------------------------------------------------------------------
-        # 3. Write results in batches
+        # 3. Streaming walk + incremental writes
         # ------------------------------------------------------------------
-        groups_found = len(burst_groups)
+        FETCH_SIZE = 1000      # rows fetched from DB per round-trip
+        WRITE_BATCH_SIZE = 500 # rows per commit
+
+        groups_found = 0
         files_updated = 0
         files_skipped = 0
         errors = 0
-        batch_writes: list[tuple] = []  # (favorites_json, burst_count, path)
+        pending_writes: list[tuple] = []  # (favorites_json, burst_count, path)
+        current_group: list = []
 
-        for group in burst_groups:
-            burst_count = len(group)
-            favorited_filenames = [
-                r["filename"] for r in group if r.get("is_favorited")
-            ]
-            favorites_json = json.dumps(favorited_filenames) if favorited_filenames else None
-
-            for row in group:
-                batch_writes.append((favorites_json, burst_count, row["path"]))
-
-        # Execute in batches of 500
-        BATCH_SIZE = 500
-        for batch_start in range(0, len(batch_writes), BATCH_SIZE):
-            batch = batch_writes[batch_start: batch_start + BATCH_SIZE]
-            for favorites_json, burst_count, path in batch:
+        async def _flush_writes():
+            nonlocal files_updated, files_skipped, errors
+            for favorites_json, burst_count, path in pending_writes:
                 try:
                     async with self._db.execute(
                         """UPDATE exif_data
                                SET burst_favorites = ?, burst_count = ?
                              WHERE file_id = (SELECT id FROM media_files WHERE path = ?)""",
                         (favorites_json, burst_count, path),
-                    ) as cursor:
-                        if cursor.rowcount > 0:
+                    ) as upd_cursor:
+                        if upd_cursor.rowcount > 0:
                             files_updated += 1
                         else:
                             files_skipped += 1
                 except Exception as exc:
                     _LOGGER.warning("index_burst_groups: error updating %s: %s", path, exc)
                     errors += 1
-
             await self._db.commit()
+            pending_writes.clear()
 
-            processed_so_far = min(batch_start + BATCH_SIZE, len(batch_writes))
-            _LOGGER.debug(
-                "index_burst_groups: committed batch (%d/%d rows written)",
-                processed_so_far, len(batch_writes)
-            )
-            if progress_callback:
-                try:
-                    await progress_callback(groups_found, processed_so_far)
-                except Exception:
-                    pass
+        async def _commit_group(members):
+            nonlocal groups_found
+            clusters = _gps_cluster(members) if any(
+                r.get("latitude") is not None for r in members
+            ) else [members]
+
+            for cluster in clusters:
+                if len(cluster) < min_group_size:
+                    continue
+                groups_found += 1
+                burst_count = len(cluster)
+                favorited_filenames = [r["filename"] for r in cluster if r.get("is_favorited")]
+                favorites_json = json.dumps(favorited_filenames) if favorited_filenames else None
+                for row in cluster:
+                    pending_writes.append((favorites_json, burst_count, row["path"]))
+
+            if len(pending_writes) >= WRITE_BATCH_SIZE:
+                await _flush_writes()
+                _LOGGER.debug(
+                    "index_burst_groups: wrote batch — groups=%d, updated=%d",
+                    groups_found, files_updated,
+                )
+                if progress_callback:
+                    try:
+                        await progress_callback(groups_found, files_updated + files_skipped)
+                    except Exception:
+                        pass
+
+        async with self._db.execute(query, params) as cursor:
+            while True:
+                raw_batch = await cursor.fetchmany(FETCH_SIZE)
+                if not raw_batch:
+                    break
+                total_rows_seen += len(raw_batch)
+                for raw_row in raw_batch:
+                    row = dict(raw_row)
+                    if current_group:
+                        prev_time = current_group[-1]["date_taken"]
+                        curr_time = row["date_taken"]
+                        if (
+                            curr_time is not None
+                            and prev_time is not None
+                            and (curr_time - prev_time) <= time_window_seconds
+                        ):
+                            current_group.append(row)
+                        else:
+                            await _commit_group(current_group)
+                            current_group = [row]
+                    else:
+                        current_group = [row]
+
+        # Finalise the last group and flush any remaining writes
+        if current_group:
+            await _commit_group(current_group)
+        if pending_writes:
+            await _flush_writes()
+
+        _LOGGER.info("index_burst_groups: processed %d rows", total_rows_seen)
 
         _LOGGER.info(
             "index_burst_groups: done — groups=%d, updated=%d, skipped=%d, errors=%d",

--- a/custom_components/media_index/cache_manager.py
+++ b/custom_components/media_index/cache_manager.py
@@ -1927,7 +1927,7 @@ class CacheManager:
         current_group: list = []
 
         async def _flush_writes():
-            nonlocal files_updated, files_skipped, errors
+            nonlocal files_updated, errors
             if not pending_writes:
                 return
             try:
@@ -1966,7 +1966,7 @@ class CacheManager:
                 )
                 if progress_callback:
                     try:
-                        await progress_callback(groups_found, files_updated + files_skipped)
+                        await progress_callback(groups_found, files_updated)
                     except Exception:
                         pass
 

--- a/custom_components/media_index/const.py
+++ b/custom_components/media_index/const.py
@@ -119,6 +119,7 @@ SERVICE_MARK_FOR_EDIT: Final = "mark_for_edit"
 SERVICE_RESTORE_EDITED_FILES: Final = "restore_edited_files"
 SERVICE_CLEANUP_DATABASE: Final = "cleanup_database"
 SERVICE_UPDATE_BURST_METADATA: Final = "update_burst_metadata"
+SERVICE_INDEX_BURST_GROUPS: Final = "index_burst_groups"
 SERVICE_INSTALL_LIBMEDIAINFO: Final = "install_libmediainfo"
 SERVICE_CHECK_FILE_EXISTS: Final = "check_file_exists"
 

--- a/custom_components/media_index/manifest.json
+++ b/custom_components/media_index/manifest.json
@@ -16,5 +16,5 @@
     "mutagen>=1.47.0",
     "pymediainfo>=6.0.0"
   ],
-  "version": "1.5.10"
+  "version": "1.6.0"
 }

--- a/custom_components/media_index/services.yaml
+++ b/custom_components/media_index/services.yaml
@@ -486,3 +486,62 @@ check_file_exists:
       example: "media-source://media_source/media/photo/Photos/2023/IMG_001.jpg"
       selector:
         text:
+
+index_burst_groups:
+  name: Index Burst Groups
+  description: >
+    Scan the entire indexed library and write burst_count / burst_favorites to every
+    file that belongs to a detected burst group. Designed for large collections
+    (200 K+ items). Uses a single sorted pass — no per-file queries. Run this once
+    after the initial library scan, or whenever you want to refresh burst data across
+    the whole library.
+  target:
+    entity:
+      integration: media_index
+      domain: sensor
+  fields:
+    folder:
+      name: Folder
+      description: Limit the scan to files under this folder prefix. Omit to scan the entire library.
+      required: false
+      example: "/media/photo/PhotoLibrary/Bursts"
+      selector:
+        text:
+    time_window_seconds:
+      name: Time Window (seconds)
+      description: Maximum gap in seconds between consecutive photos in the same burst group.
+      required: false
+      default: 10
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: s
+    location_tolerance_meters:
+      name: Location Tolerance (metres)
+      description: GPS radius in metres for grouping photos at the same location. Photos without GPS coordinates are grouped by time only.
+      required: false
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 1000
+          unit_of_measurement: m
+    min_group_size:
+      name: Minimum Group Size
+      description: Minimum number of photos required to be considered a burst group.
+      required: false
+      default: 2
+      selector:
+        number:
+          min: 2
+          max: 20
+    overwrite_existing:
+      name: Overwrite Existing
+      description: >
+        If true (default), recalculate and overwrite burst_count / burst_favorites for all
+        matching files. If false, only populate files that have no existing burst_count.
+      required: false
+      default: true
+      selector:
+        boolean:

--- a/custom_components/media_index/services.yaml
+++ b/custom_components/media_index/services.yaml
@@ -87,6 +87,12 @@ get_random_items:
           min: 60
           max: 86400
           mode: box
+    auto_select_burst_favorite:
+      name: Auto-Select Burst Favorite
+      description: Exclude non-favorite images from burst groups that have an indexed favorite (requires index_burst_groups to have been run first)
+      default: false
+      selector:
+        boolean:
 
 get_ordered_files:
   name: Get Ordered Media Files

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -338,10 +338,10 @@ data:
 - `errors`: Number of files that could not be written
 
 **How it works:**
-- Sorts all indexed files by `date_taken` (O(n log n))
-- Walks the sorted list grouping consecutive photos within the configured time window
-- Sub-clusters by GPS proximity when coordinates are available for all group members
-- Writes `burst_count` and `burst_favorites` to `exif_data` in 500-row batches
+- Streams all indexed files sorted by `date_taken` using 1000-row fetch batches — memory footprint is O(burst_size), not O(library_size)
+- Groups consecutive photos within the configured time window; each group is processed and written immediately when complete
+- Sub-clusters by GPS proximity when coordinates are available for group members
+- Writes `burst_count` and `burst_favorites` to `exif_data` in 500-row commit batches
 - Idempotent: safe to run multiple times; already-correct rows are skipped when `overwrite_existing: false`
 
 **Example:**

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -323,33 +323,42 @@ data:
 
 **New in v1.6.0** - Scan the entire library and write burst group membership to every file. Run this once (or after bulk imports) to enable database-level burst filtering in `get_random_items`.
 
-**Parameters:** None
+**Parameters:**
+- `folder` (optional): Limit the scan to files under this folder prefix. Omit to scan the entire library.
+- `time_window_seconds` (optional, default: 10): Maximum gap in seconds between consecutive photos in the same burst group.
+- `location_tolerance_meters` (optional, default: 50): GPS radius in metres for grouping photos at the same location. Use 0 to disable GPS sub-clustering.
+- `min_group_size` (optional, default: 2): Minimum number of photos required to be considered a burst group.
+- `overwrite_existing` (optional, default: true): If true, recalculate burst data for all matching files. If false, skip files that already have `burst_count` set.
 
 **Returns:**
-- `status`: `"ok"` or `"error"`
+- `status`: `"success"` or `"error"`
 - `groups_found`: Number of distinct burst groups identified
 - `files_updated`: Number of files written with burst metadata
 - `files_skipped`: Files already up-to-date (no change needed)
 - `errors`: Number of files that could not be written
 
 **How it works:**
-- Sorts all indexed files by `date_taken` / `created_time` (O(n log n))
-- Walks the sorted list grouping photos within a 15-second sliding window
-- Sub-clusters by GPS proximity (20m) when coordinates are available
-- Writes `burst_group_id` (UUID), `burst_count`, and `burst_favorites` to `exif_data` in 500-row batches
-- Idempotent: safe to run multiple times; already-correct rows are skipped
+- Sorts all indexed files by `date_taken` (O(n log n))
+- Walks the sorted list grouping consecutive photos within the configured time window
+- Sub-clusters by GPS proximity when coordinates are available for all group members
+- Writes `burst_count` and `burst_favorites` to `exif_data` in 500-row batches
+- Idempotent: safe to run multiple times; already-correct rows are skipped when `overwrite_existing: false`
 
 **Example:**
 ```yaml
 service: media_index.index_burst_groups
 target:
   entity_id: sensor.media_index_photos_total_files
+data:
+  time_window_seconds: 10
+  location_tolerance_meters: 50
+  min_group_size: 2
 ```
 
 **Response example:**
 ```json
 {
-  "status": "ok",
+  "status": "success",
   "groups_found": 842,
   "files_updated": 3107,
   "files_skipped": 41823,

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -116,7 +116,8 @@ Get random media files from the index (used by Media Card).
 - `anniversary_day` (optional): Day for anniversary matching (`"01"`-`"31"` or `"*"` for any day)
 - `anniversary_window_days` (optional, default: 0): Expand ±N days around target date for anniversary matching
 - `priority_new_files` (optional, default: false): Prioritize recently scanned files
-- `new_files_threshold_seconds` (optional, default: 3600): Seconds threshold for "new" files (1 hour) 
+- `new_files_threshold_seconds` (optional, default: 3600): Seconds threshold for "new" files (1 hour)
+- `auto_select_burst_favorite` (optional, default: false): Exclude non-favorite images from burst groups that have an indexed favorite (requires `index_burst_groups` to have been run first)
 
 **Returns:** List of media items with metadata (includes `media_source_uri` in v1.4+)
 
@@ -317,6 +318,46 @@ data:
   media_source_uri: media-source://media_source/media/Photo/PhotoLibrary/IMG_1234.jpg
   prefer_same_location: false
 ```
+
+### `media_index.index_burst_groups`
+
+**New in v1.5.10** - Scan the entire library and write burst group membership to every file. Run this once (or after bulk imports) to enable database-level burst filtering in `get_random_items`.
+
+**Parameters:** None
+
+**Returns:**
+- `status`: `"ok"` or `"error"`
+- `groups_found`: Number of distinct burst groups identified
+- `files_updated`: Number of files written with burst metadata
+- `files_skipped`: Files already up-to-date (no change needed)
+- `errors`: Number of files that could not be written
+
+**How it works:**
+- Sorts all indexed files by `date_taken` / `created_time` (O(n log n))
+- Walks the sorted list grouping photos within a 15-second sliding window
+- Sub-clusters by GPS proximity (20m) when coordinates are available
+- Writes `burst_group_id` (UUID), `burst_count`, and `burst_favorites` to `exif_data` in 500-row batches
+- Idempotent: safe to run multiple times; already-correct rows are skipped
+
+**Example:**
+```yaml
+service: media_index.index_burst_groups
+target:
+  entity_id: sensor.media_index_photos_total_files
+```
+
+**Response example:**
+```json
+{
+  "status": "ok",
+  "groups_found": 842,
+  "files_updated": 3107,
+  "files_skipped": 41823,
+  "errors": 0
+}
+```
+
+**Tip:** After running `index_burst_groups`, enable `auto_select_burst_favorite: true` in Media Card and the card will automatically receive only favorited images from burst groups — no 2-second timers, no client-side splicing.
 
 ### `media_index.update_burst_metadata`
 
@@ -535,10 +576,22 @@ The Media Index services integrate seamlessly with the [Home Assistant Media Car
 - **`get_ordered_files`** - Used automatically by Media Card for sequential slideshow mode (v1.3)
 - **`get_related_files`** (v1.5+) - Powers "Burst Review" feature for reviewing rapid-fire photos
 - **`update_burst_metadata`** (v1.5+) - Saves burst review favorites to file metadata
+- **`index_burst_groups`** (v1.5.10+) - One-shot library scan that enables backend-level burst filtering in `get_random_items`
 - **`mark_favorite`** - Called when clicking favorite button on Media Card
 - **`delete_media`** - Called when clicking delete button on Media Card
 - **`mark_for_edit`** - Called when clicking edit button on Media Card
 - **`restore_edited_files`** - Run periodically to restore edited files
+
+## v1.5.10 Enhancements Summary
+
+### New Services
+- ✨ **`index_burst_groups`** - Full-library burst indexer; enables SQL-level filtering of non-favorite burst members
+
+### Enhanced Services
+- 🌟 **`get_random_items`** - Added `auto_select_burst_favorite` parameter; non-favorite burst members are excluded in the database query before results reach the card
+
+### Bug Fixes
+- 🐛 **`get_burst_photos`** - Iterative flood-fill for consistent group membership regardless of reference photo
 
 ## v1.5 Enhancements Summary
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -321,7 +321,7 @@ data:
 
 ### `media_index.index_burst_groups`
 
-**New in v1.5.10** - Scan the entire library and write burst group membership to every file. Run this once (or after bulk imports) to enable database-level burst filtering in `get_random_items`.
+**New in v1.6.0** - Scan the entire library and write burst group membership to every file. Run this once (or after bulk imports) to enable database-level burst filtering in `get_random_items`.
 
 **Parameters:** None
 
@@ -576,13 +576,13 @@ The Media Index services integrate seamlessly with the [Home Assistant Media Car
 - **`get_ordered_files`** - Used automatically by Media Card for sequential slideshow mode (v1.3)
 - **`get_related_files`** (v1.5+) - Powers "Burst Review" feature for reviewing rapid-fire photos
 - **`update_burst_metadata`** (v1.5+) - Saves burst review favorites to file metadata
-- **`index_burst_groups`** (v1.5.10+) - One-shot library scan that enables backend-level burst filtering in `get_random_items`
+- **`index_burst_groups`** (v1.6.0+) - One-shot library scan that enables backend-level burst filtering in `get_random_items`
 - **`mark_favorite`** - Called when clicking favorite button on Media Card
 - **`delete_media`** - Called when clicking delete button on Media Card
 - **`mark_for_edit`** - Called when clicking edit button on Media Card
 - **`restore_edited_files`** - Run periodically to restore edited files
 
-## v1.5.10 Enhancements Summary
+## v1.6.0 Enhancements Summary
 
 ### New Services
 - ✨ **`index_burst_groups`** - Full-library burst indexer; enables SQL-level filtering of non-favorite burst members


### PR DESCRIPTION
### Added

- **`index_burst_groups` Service**: One-shot service that scans the entire library (O(n log n)) and writes `burst_favorites` and `burst_count` to every file in every burst group
  - Groups photos by time proximity (10s window, configurable) and optional GPS sub-clustering (50m tolerance, configurable)
  - Streams rows from the database in 1000-row batches — memory footprint is O(burst_size), not O(library_size); safe for 200K+ libraries
  - Writes results in 500-row commit batches
  - Returns `{groups_found, files_updated, files_skipped, errors}` for progress feedback
  - Run this once (or after bulk imports) to enable backend-level burst filtering in `get_random_items`
  - See `media_index.index_burst_groups` in the services documentation

- **`auto_select_burst_favorite` Parameter for `get_random_items`**: When `true`, the SQL query excludes non-favorite burst members whose group has at least one indexed favorite
  - Filtering is done in the database before results are sent to the card — no client-side splicing or timers
  - Only applies to files where `burst_count` is set (i.e., `index_burst_groups` has run); non-indexed files are returned normally
  - Used automatically by Media Card v5.9.0+ when `auto_select_burst_favorite: true` is configured


### Fixed

- **`index_burst_groups` Now Clears Stale Burst Data Before Re-indexing**: Re-running with a narrower time window now correctly removes burst groups from files that no longer qualify
  - Previously, files previously in a group (e.g. with a 15s window) kept their old `burst_count` when re-indexed with a narrower window (e.g. 3s) — causing the metadata header to show the old count while the live burst panel query found fewer photos
  - Fix: all in-scope `burst_count` and `burst_favorites` values are reset before new groups are written (only when `overwrite_existing=True`)

- **Date Filtering Now Works for Files Without EXIF (`get_random_items`, `get_ordered_files`)**: Fixed silent type mismatch that caused date filters to be ignored when `date_taken` is NULL
  - Root cause (PR #25 by kamiyo): `m.created_time` and `m.modified_time` are stored as ISO strings, but `e.date_taken` is a Unix integer. When `e.date_taken` is NULL, `COALESCE` fell back to the ISO string which SQLite silently coerced to 0 — so comparisons against Unix timestamps always failed
  - Fix: wrap fallback columns with `unixepoch()` to convert ISO strings to integers before comparison
  - Also fixes `strftime()` anniversary filters for the same reason (month/day matching was broken for files without EXIF)

- **Date Fallback Now Uses Earliest of Created/Modified Time**: When `date_taken` EXIF is absent, filtering and sorting now use `MIN(unixepoch(m.created_time), unixepoch(m.modified_time))` instead of only `m.created_time`
  - Fixes issue #24 (reported by kamiyo): copying files resets `created_time` to "now" on most OS/filesystems, causing old photos to appear as new — `modified_time` typically survives file copies and better reflects the original capture date
  - Using the earlier of the two timestamps is the most conservative heuristic: whichever one was not reset by the copy is more likely the original date
  - Applies to all date range filters, anniversary filters, and `date_taken` sort order in `get_ordered_files`

- **`get_burst_photos` Iterative Flood-Fill**: Replaced naive single-pass grouping with an iterative convergence algorithm so all members of a burst group get the same result regardless of which photo is used as the reference
  - Previously, a 3-photo burst could return 2 members when queried from photo A and 3 members when queried from photo B (depending on which pair was within the time window of the reference)
  - Now iterates until the full connected set stabilises (typically 1–2 passes on real bursts)
